### PR TITLE
fix(zsh): 修正 ccm/ccw 路徑 bug 並清理設定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,258 @@
+# AGENTS.md — AI Assistant Guide for mac-setting
+
+This file provides context for AI assistants (Codex, Copilot, etc.) working in this repository.
+
+## Repository Overview
+
+`mac-setting` is a **macOS developer environment dotfiles and setup repository** for backend engineers. It provides:
+- A modular zsh configuration (`.zshenv`, `.zprofile`, `.zshrc`, `.zlogin`, `.zshshell`)
+- A Neovim config built on [LazyVim](https://www.lazyvim.org/)
+- Tmux configuration with TPM plugins
+- An automated setup script (`setup.sh`) that installs tools via Homebrew
+- Git commit conventions via `commitizen` + `commitlint`
+
+The repository uses **symlinks** to install configs: `setup.sh` links files from this repo into `$HOME`.
+
+---
+
+## Repository Structure
+
+```
+mac-setting/
+├── setup.sh                   # Main installer script (Bash, strict mode)
+├── setup.sh.backup            # Auto-generated backup; do not edit
+├── README.md                  # User-facing documentation (Traditional Chinese)
+├── AGENTS.md                  # This file
+│
+├── zsh/                       # Zsh configuration files
+│   ├── .zshenv                # All zsh instances: env vars, PATH
+│   ├── .zprofile              # Login shell: Homebrew env, OrbStack
+│   ├── .zshrc                 # Interactive shell: theme, aliases, plugins
+│   ├── .zlogin                # Post-login: welcome message, system info
+│   └── .zshshell              # Custom fzf-enhanced shell functions
+│
+├── nvim/                      # Neovim config (LazyVim-based)
+│   ├── init.lua               # Entry point, loads lazy.lua
+│   ├── lazy-lock.json         # Plugin lockfile (commit when updating plugins)
+│   ├── lazyvim.json           # LazyVim extras config
+│   └── lua/
+│       ├── config/
+│       │   ├── autocmds.lua   # Auto-commands
+│       │   ├── keymaps.lua    # Custom keymaps
+│       │   ├── lazy.lua       # Lazy.nvim bootstrap
+│       │   └── options.lua    # Vim options
+│       └── plugins/
+│           ├── editor.lua     # Telescope, Neo-tree, editing tools
+│           ├── theme.lua      # Colorscheme
+│           ├── ui.lua         # UI enhancements
+│           └── vscode.lua     # VSCode-specific overrides
+│
+├── tmux/
+│   └── .tmux.conf             # Tmux config; prefix = Ctrl-a, theme = Catppuccin Mocha
+│
+├── gitcz/                     # Commitizen configuration
+│   ├── .cz-config.js          # Commit types and messages (Traditional Chinese)
+│   ├── .commitlintrc.js       # Commitlint rules
+│   ├── .czrc                  # Commitizen adapter pointer
+│   └── .git-czrc              # Git-cz config
+│
+└── theme/
+    ├── iTerm2/tokyonight/     # iTerm2 color scheme
+    └── catppuccin/iterm/      # Git submodule: catppuccin iTerm theme
+```
+
+---
+
+## Zsh Configuration Architecture
+
+Understanding the load order is critical when modifying zsh files:
+
+| File | When loaded | Responsible for |
+|------|-------------|-----------------|
+| `.zshenv` | Every zsh instance (login, interactive, scripts) | `PATH`, env vars, FZF config, Go/Node/tool paths |
+| `.zprofile` | Login shells only, before `.zshrc` | `brew shellenv`, OrbStack integration |
+| `.zshrc` | Interactive shells | Powerlevel10k theme, aliases, zplug plugins, completions |
+| `.zlogin` | Login shells, after `.zshrc` | Welcome banner, system info via `macchina` |
+| `.zshshell` | Sourced from `.zshrc` | Custom fzf functions (`ff`, `fcd`, `vg`, `ftm`, etc.) |
+
+**Key convention**: Environment variables and PATH belong in `.zshenv`. Aliases, plugins, and interactive tools belong in `.zshrc`. Never mix these.
+
+### Local overrides
+`~/.zshrc.local` is sourced at the end of `.zshrc` if it exists. Use it for machine-specific settings, API keys, and secrets that must not be committed.
+
+---
+
+## setup.sh — The Installer
+
+`setup.sh` runs with `set -euo pipefail` (strict mode). It requires macOS and Homebrew.
+
+### Commands
+
+```bash
+./setup.sh all           # Full install (recommended for new machines)
+./setup.sh zsh           # Zsh config + dependency tools
+./setup.sh tmux          # Tmux + TPM
+./setup.sh nvim          # Neovim + symlink ~/.config/nvim
+./setup.sh backend       # Docker/k8s, Go, Node.js, cloud tools
+./setup.sh golang        # Go language + dev tools only
+./setup.sh ai-tools      # Codex CLI, Gemini CLI
+./setup.sh gui-tools     # Raycast, Warp, Stats, AppCleaner (Cask)
+./setup.sh vim-repeat    # Disable macOS key-hold delay for Vim
+./setup.sh health        # Check what is/isn't installed
+```
+
+### Important behaviors
+- `safe_symlink`: backs up existing files as `<file>.backup.YYYYMMDD_HHMMSS` before linking
+- `safe_brew_install`: skips if the binary already exists
+- `safe_brew_cask_install`: always attempts install, warns on failure
+- Go tools are installed to `$GOPATH/bin` via `go install <pkg>@latest`
+- Node.js is managed via `fnm`; the script installs the LTS version and sets it as default
+
+---
+
+## Neovim Configuration
+
+Based on **LazyVim**. Plugin management via `lazy.nvim`.
+
+### Custom plugin files
+
+| File | Contents |
+|------|----------|
+| `lua/plugins/editor.lua` | Telescope (find files: `<leader>ff`, live grep: `;r`, diagnostics: `;e`), Neo-tree, numb.nvim, multi-cursor, mini.surround, mini.comment, conform.nvim (proto formatting via `buf`), nvim-lint (proto lint via `buf_lint`) |
+| `lua/plugins/theme.lua` | Colorscheme setup |
+| `lua/plugins/ui.lua` | UI enhancements |
+| `lua/plugins/vscode.lua` | VSCode-specific overrides |
+
+### Telescope keymaps
+- `<leader>ff` — find files
+- `;r` — live grep (includes hidden files)
+- `;e` — diagnostics
+- `;s` — Treesitter symbols
+- In picker: `Ctrl-j/k` navigate, `Ctrl-c` close, `Ctrl-t` open in Trouble
+
+### Mini.surround mappings
+`gsa` add, `gsd` delete, `gsf`/`gsF` find, `gsh` highlight, `gsr` replace, `gsn` update n_lines
+
+### mini.comment
+`<leader>/` — toggle comment (normal, visual, line)
+
+### Neo-tree
+- Always shows `.gitignore`, `.dockerignore`, `.github`, `.env*`
+- `v` — open in vertical split
+- `<space>` — disabled (reserved for leader)
+
+---
+
+## Tmux Configuration
+
+- **Prefix**: `Ctrl-a` (not the default `Ctrl-b`)
+- **Theme**: Catppuccin Mocha
+- **Base index**: windows and panes start at 1
+- Key bindings:
+  - `Prefix + r` — reload config
+  - `Prefix + X` — kill window
+  - `Ctrl-l` — clear screen + history
+  - `Prefix + Ctrl-b` — toggle synchronize panes
+  - `Ctrl-f` — open `tmux-fzf`
+  - Copy mode: `v` begin selection, `y` copy
+
+### TPM Plugins
+`tmux-pain-control`, `tmux-sensible`, `tmux-sessionist`, `tmux-copycat`, `tmux-yank`, `tmux-resurrect`, `tmux-continuum`, `tmux-open`, `tmux-prefix-highlight`, `catppuccin/tmux`, `sainnhe/tmux-fzf`
+
+---
+
+## Custom Shell Functions (`.zshshell`)
+
+All functions check for required tools and print errors if missing.
+
+| Function | Usage | Description |
+|----------|-------|-------------|
+| `ff [pattern]` | `ff config` | Find file with fd + fzf, open in `$EDITOR` |
+| `fcd [pattern]` | `fcd src` | Find directory, `cd` into it |
+| `vg <pattern>` | `vg "func"` | ripgrep + fzf, open file at matching line |
+| `ftm [session]` | `ftm work` | Create or attach to tmux session |
+| `fs [pattern]` | `fs` | Quick tmux session switch |
+| `fkill [signal]` | `fkill` | Multi-select processes and kill (default signal 9) |
+| `fdim` | `fdim` | Select and remove Docker images |
+| `fdc [action]` | `fdc logs` | Manage Docker containers (start/stop/restart/remove/logs/exec) |
+| `fgb` | `fgb` | fzf branch switcher (`git checkout`) |
+| `fgl` | `fgl` | Browse git log with diff preview |
+| `myip` | `myip` | Show local + public IP with geolocation |
+| `sysinfo` | `sysinfo` | CPU, RAM, uptime summary |
+| `fzf_help` | `fzf_help` | Print all function descriptions |
+
+---
+
+## Git Commit Conventions
+
+This repo uses **commitizen** with a custom config in `gitcz/`. Commit types:
+
+| Type | Meaning |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring (not a feature or fix) |
+| `docs` | Documentation changes |
+| `test` | Adding or modifying tests |
+| `chore` | Build process, packaging, tooling changes |
+| `style` | Formatting only (whitespace, semicolons) |
+| `revert` | Reverting a previous commit |
+| `WIP` | Work in progress |
+
+Breaking changes are allowed in `feat`, `fix`, and `refactor`. Subject line is uppercased. Related issues go in the footer as `Related issue: #123`.
+
+Commit messages in this repo are primarily written in **Traditional Chinese**.
+
+---
+
+## Key Environment Variables (`.zshenv`)
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `HOMEBREWOPT` | `/opt/homebrew` | Homebrew prefix (Apple Silicon) |
+| `GOROOT` | `$HOMEBREWOPT/opt/go/libexec` | Go installation |
+| `GOPATH` | `$HOME/go` | Go workspace |
+| `GOPROXY` | `https://proxy.golang.org` | Go module proxy |
+| `BUN_INSTALL` | `$HOME/.bun` | Bun runtime |
+| `ZPLUG_HOME` | `$HOMEBREWOPT/opt/zplug` | Zplug plugin manager |
+| `EDITOR` / `VISUAL` | `nvim` | Default editor |
+| `FZF_DEFAULT_COMMAND` | `fd --type file --hidden ...` | fzf file source |
+| `FZF_DEFAULT_OPTS` | Catppuccin Mocha colors | fzf appearance |
+
+PATH is built using `typeset -U path` (no duplicates) with `add_to_path()` for conditional additions.
+
+---
+
+## Development Workflow
+
+### Adding a new tool to setup.sh
+1. Add to the appropriate array in the relevant `setup_*` function
+2. Use `tool_name:description` format for the array entry
+3. Use `safe_brew_install` for CLI tools, `safe_brew_cask_install` for GUI apps
+
+### Adding a new zsh function
+1. Add to `zsh/.zshshell`
+2. Include a dependency check (`command -v <tool>`) at the top
+3. Add an entry to the `fzf_help` function at the bottom of the file
+
+### Adding a Neovim plugin
+1. Create or edit a file in `nvim/lua/plugins/`
+2. Return a table of plugin specs per lazy.nvim format
+3. Run `:Lazy sync` in Neovim; commit the updated `lazy-lock.json`
+
+### Updating symlinks
+Run the relevant `setup.sh` command again — `safe_symlink` handles re-linking idempotently.
+
+### Secrets and local config
+Never commit API keys or personal tokens. Use `~/.zshrc.local` (gitignored by convention) for local overrides.
+
+---
+
+## What NOT to Do
+
+- Do not add aliases, functions, or plugin loading to `.zshenv` — it is loaded in non-interactive contexts (scripts, cron jobs) where those constructs are inappropriate
+- Do not hardcode `$HOME/Users/maxjkfc` paths in shared config files — use `$HOME` instead
+- Do not commit `*.backup` files or `*.backup.*` files — they are auto-generated by `safe_symlink`
+- Do not edit `setup.sh.backup` — it is an auto-generated snapshot
+- Do not modify `nvim/plugin/` — it is gitignored and managed by lazy.nvim at runtime
+- Do not skip `set -euo pipefail` behavior when extending `setup.sh` — errors should always be surfaced

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -5,3 +5,5 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Added by Obsidian
 export PATH="$PATH:/Applications/Obsidian.app/Contents/MacOS"
+
+# 註：$HOME/.local/bin 已在 .zshenv 透過 add_to_path 加入，毋須在此重複

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -10,8 +10,9 @@
 # ============================================================================
 
 # Language and Locale
+# 只設 LANG；不設 LC_ALL（LC_ALL 會強制覆蓋所有 LC_* 分類，
+# 留空可讓時間/排序等個別分類跟隨系統設定）
 export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
 
 # Default Editor and Browser
 export EDITOR='nvim'
@@ -62,7 +63,7 @@ export ZPLUG_HOME="$HOMEBREWOPT/opt/zplug"
 # ============================================================================
 # Obsidian
 # ============================================================================
-export OBSIDIAN_HOME="$HOME/Library/Mobile\ Documents/iCloud~md~obsidian/Documents"
+export OBSIDIAN_HOME="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
 
 # ============================================================================
 # Claude Code
@@ -90,14 +91,13 @@ add_to_path() {
 # 按優先級順序添加路徑
 add_to_path "$HOME/.local/bin"
 add_to_path "$HOME/.antigravity/antigravity/bin"
-add_to_path "$OPENJAVA_PATH"
 add_to_path "$COREPATH"
 add_to_path "$GOROOT/bin"
 add_to_path "$GOPATH/bin"
-add_to_path "$LINKERD_HOME/bin"
 add_to_path "$BUN_INSTALL/bin"
 add_to_path "$ZPLUG_HOME/bin"
 add_to_path "$HOMEBREWOPT/bin"
+add_to_path "$HOMEBREWOPT/opt/curl/bin"
 add_to_path "$PQSQL_HOME/bin"
 
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -24,6 +24,20 @@ setopt prompt_subst
 set -o emacs
 
 # ============================================================================
+# HISTORY
+# ============================================================================
+# 明確版控 history 設定（先前值來自 plugin/系統預設，過小且不可控）
+HISTFILE="$HOME/.zsh_history"
+HISTSIZE=50000          # 記憶體內保留的行數
+SAVEHIST=50000          # 寫入 HISTFILE 的行數
+setopt SHARE_HISTORY        # 多個 session 即時共享 history
+setopt HIST_IGNORE_DUPS     # 不記錄與前一筆相同的指令
+setopt HIST_IGNORE_ALL_DUPS # 新指令重複時刪除舊的同名項
+setopt HIST_IGNORE_SPACE    # 以空白開頭的指令不入 history（敏感操作用）
+setopt HIST_REDUCE_BLANKS   # 寫入前壓掉多餘空白
+setopt HIST_VERIFY          # 展開 history 後先顯示、不直接執行
+
+# ============================================================================
 # POWERLEVEL10K THEME
 # ============================================================================
 
@@ -69,7 +83,7 @@ alias ll='eza -lbhHigUmua --git'
 # File Operations
 alias mv='mv -i'
 alias cp='cp -i'
-alias rm='rm -i'
+# rm 的定義集中在下方「安全刪除」區塊（trash），此處不重複
 
 # Editor
 alias v='nvim'
@@ -83,9 +97,8 @@ alias egrep='egrep --color=auto'
 # Tools
 alias cat='bat'
 alias mtr='sudo mtr'
-alias git='$HOMEBREWOPT/bin/git'
-alias curl='$HOMEBREWOPT/opt/curl/bin/curl'
 alias sed="gsed"
+# 註：git / curl 改由 PATH 解析（見 .zshenv 的 add_to_path），不再用絕對路徑 alias
 
 # File Extensions
 alias -s sh="sh"
@@ -97,8 +110,9 @@ alias -s bz2="tar -xjvf"
 
 # Claude code
 alias  cc="CLAUDE_CODE_NO_FLICKER=1 claude"
-alias  ccm="cd $OBSIDIAN_HOME/max-agent && CLAUDE_CODE_NO_FLICKER=1 claude"
-alias  ccw="cd $OBSIDIAN_HOME/max-wiki && CLAUDE_CODE_NO_FLICKER=1 claude"
+alias  ccr="CLAUDE_CODE_NO_FLICKER=1 claude remote-control"
+alias  ccm='cd "$OBSIDIAN_HOME/max-agent" && CLAUDE_CODE_NO_FLICKER=1 claude'
+alias  ccw='cd "$OBSIDIAN_HOME/max-wiki" && CLAUDE_CODE_NO_FLICKER=1 claude'
 
 # ═══════════════════════════════════════════════════════════════
 # 安全刪除 - rm 改用垃圾桶（可還原）
@@ -166,6 +180,17 @@ if [[ -f "$ZPLUG_HOME/init.zsh" ]]; then
     # Load plugins
     zplug load
 
+fi
+
+# ============================================================================
+# HISTORY SUBSTRING SEARCH KEYBINDINGS
+# ============================================================================
+# 必須在 zplug load 之後綁定，否則 widget 尚未定義（先前載入但未綁鍵 = 無作用）
+if (( $+widgets[history-substring-search-up] )); then
+    bindkey '^[[A' history-substring-search-up      # ↑
+    bindkey '^[[B' history-substring-search-down    # ↓
+    bindkey '^P'   history-substring-search-up      # emacs 慣用
+    bindkey '^N'   history-substring-search-down
 fi
 
 # ============================================================================


### PR DESCRIPTION
## 摘要

修正一個會讓 `ccm`/`ccw` 直接失效的 bug，並順手清理 zsh 設定的冗餘與補強 history/keybinding。

## 主要修正（P1）

- **`OBSIDIAN_HOME` 字面反斜線導致 `ccm`/`ccw` 必定失敗**：`.zshenv` 在雙引號內寫 `Mobile\ Documents`，雙引號不處理 `\ `，變數中存入字面反斜線，`cd` 必定報 `no such file or directory`。改為不跳脫空格、使用端以引號包覆。
- `ccm`/`ccw` 改用單引號定義，`$OBSIDIAN_HOME` 延遲到使用時才展開。

## 清理（P2）

- 移除冗餘的 `git`/`curl` 絕對路徑 alias，改由 PATH 解析；keg-only curl 加入 `add_to_path` 接住。
- 移除引用未定義變數的 `add_to_path`（`OPENJAVA_PATH`、`LINKERD_HOME`，原本是 no-op）。
- 移除被 `trash` 覆蓋的 dead alias `rm='rm -i'`。
- 移除 `.zprofile` 硬編的 `/Users/maxjkfc/.local/bin`（`.zshenv` 已加入，且違反「不硬編 user 路徑」規範）。

## 功能補強

- 明確版控 history 設定：`HISTSIZE`/`SAVEHIST` 提升至 50000、開啟 `SHARE_HISTORY` 與去重/清理 opt（先前值來自 plugin/系統預設，過小且不可控）。
- 為 `zsh-history-substring-search` 綁定 ↑↓ 與 `^P`/`^N`（先前載入但未綁鍵，等於無作用）。
- 移除 `LC_ALL`，只留 `LANG`，讓個別 `LC_*` 分類可跟隨系統。

## 驗證

- 5 個 zsh 檔 `zsh -n` 語法檢查全過。
- 乾淨環境實測：`ccm` 路徑正確解析、`git` 經 PATH 仍指向 `/opt/homebrew/bin/git`、curl 走 keg 8.20.0、`HISTSIZE=50000`、`SHARE_HISTORY ✓`、substring-search 已綁定、`LC_ALL` 未設。

## 備註

附帶納入先前未提交的 `ccr` alias（`claude remote-control`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)