### PR TITLE
feat(zsh): .zshenv 注入 GITHUB_PACKAGES_TOKEN（動態借 gh）

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -102,6 +102,16 @@ add_to_path "$PQSQL_HOME/bin"
 
 
 # ============================================================================
+# PRIVATE REGISTRY TOKENS
+# ============================================================================
+# @likochat/ui 安裝自 GitHub Packages，.npmrc 需要 GITHUB_PACKAGES_TOKEN。
+# 借 gh 登入態動態取得，避免把 PAT 硬編進這個版控檔。:- guard 確保只在
+# 尚未從父 shell 繼承時才呼叫 gh（一般開終端機只跑一次，子 shell 直接繼承）。
+# 放在 PATH 設定之後，確保非互動 `zsh -c` 也找得到 gh。
+export GITHUB_PACKAGES_TOKEN="${GITHUB_PACKAGES_TOKEN:-$(gh auth token 2>/dev/null)}"
+
+
+# ============================================================================
 # FZF CONFIGURATION
 # ============================================================================
 


### PR DESCRIPTION
## 背景
`@likochat/ui` 安裝自 GitHub Packages，consumer（bgm-web）的 `.npmrc` 以 `${GITHUB_PACKAGES_TOKEN}` 展開取得授權。本機未設此變數時 `bun install` / `bun update` 會 401。

## 改動
在 `zsh/.zshenv` 加入：
```sh
export GITHUB_PACKAGES_TOKEN="${GITHUB_PACKAGES_TOKEN:-$(gh auth token 2>/dev/null)}"
```

## 設計取捨
- **放 `.zshenv` 而非 `.zshrc`**：`.zshrc` 只在互動 shell 載入；非互動 `zsh -c`（editor task、git hook、agent 跑的 shell）只讀 `.zshenv`。實測先前 token 在 `.zshrc` 時非互動 shell 仍 401，搬到 `.zshenv` 後解決。
- **動態借 `gh auth token`，不硬編 PAT**：此檔有版控，貼死 token 會外洩；借 gh 登入態隨之更新。
- **`:-` guard**：只在尚未從父 shell 繼承時才呼叫 gh（開終端機跑一次，子 shell 直接繼承），避免每個 subshell 都 spawn gh。
- **置於 PATH 設定之後**：確保非互動 `zsh -c` 也能解析 `/opt/homebrew/bin/gh`。

## 前提
使用此變數的機器需先 `gh auth login`（mbp 已登入）。未登入時 token 為空、不影響其他用途。

## 驗證
- 非互動 `zsh -c` 解出 token（len=40）
- 繼承下 `bun install` 乾淨無 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)